### PR TITLE
New account parameters: copy, notifyFrom and resyncDelay

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -13,7 +13,6 @@ const MailComposer = require('nodemailer/lib/mail-composer');
 const { normalizePath, resolveCredentials } = require('./tools');
 
 const LIST_REFRESH_DELAY = 30 * 60 * 1000;
-const RESYNC_DELAY = 15 * 60 * 1000;
 const ENSURE_MAIN_TTL = 5 * 1000;
 
 const MAX_BACKOFF_DELAY = 10 * 60 * 1000; // 10 min
@@ -482,7 +481,7 @@ class Connection {
             this.syncMailboxes().catch(err => {
                 this.logger.error({ msg: 'Mailbox Sync Error', err });
             });
-        }, RESYNC_DELAY);
+        }, this.resyncDelay);
     }
 
     async select(path) {
@@ -559,7 +558,8 @@ class Connection {
 
         let accountData = await this.accountObject.loadAccountData();
 		
-		this.notifyfrom = accountData.notifyfrom;
+		this.notifyFrom = accountData.notifyFrom;
+		this.resyncDelay = accountData.resyncDelay * 1000;
         
 		if (!accountData.imap) {
             // can not make connection

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -558,7 +558,10 @@ class Connection {
         }
 
         let accountData = await this.accountObject.loadAccountData();
-        if (!accountData.imap) {
+		
+		this.notifyfrom = accountData.notifyfrom;
+        
+		if (!accountData.imap) {
             // can not make connection
             this.state = 'unset';
             return;
@@ -1235,7 +1238,7 @@ class Connection {
                 raw
             });
 
-            if (!this.isGmail) {
+            if (!this.isGmail && accountData.copy) {
                 // Upload message to Sent Mail folder. Gmail does this automatically.
                 try {
                     let sentMailbox = await this.getSpecialUseMailbox('\\Sent');

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -414,7 +414,7 @@ class Mailbox {
 
     async processNew(messageData, options) {
 		
-        this.logger.debug({ msg: 'New message', uid: messageData.uid, flags: Array.from(messageData.flags), test: 'Test', notifyfrom: this.connection.notifyfrom});
+        this.logger.debug({ msg: 'New message', uid: messageData.uid, flags: Array.from(messageData.flags)});
 
         options.skipLock = true;
         options.headers = false;
@@ -429,10 +429,8 @@ class Mailbox {
 		this.logger.debug({ messageDate: date });
 
 		let messageDate = moment(messageInfo.date);
-		let notifyFrom = moment(this.connection.notifyfrom);
-
-		this.logger.debug({ messageDateValue: messageDate.valueOf(), notifyFromValue: notifyFrom.valueOf() });
-		
+		let notifyFrom = moment(this.connection.notifyFrom);
+	
 		if (messageDate < notifyFrom) {
 			return
 		}

--- a/lib/mailbox.js
+++ b/lib/mailbox.js
@@ -11,6 +11,7 @@ const linkify = require('linkifyjs/html');
 const htmlToText = require('html-to-text');
 const addressparser = require('nodemailer/lib/addressparser');
 const settings = require('./settings');
+const moment = require('moment')
 
 // Do not check for flag updates using full sync more often than this value
 const FULL_SYNC_DELAY = 30 * 60 * 1000;
@@ -412,11 +413,8 @@ class Mailbox {
     }
 
     async processNew(messageData, options) {
-        this.logger.debug({ msg: 'New message', uid: messageData.uid, flags: Array.from(messageData.flags) });
-        if (this.listingEntry.isNew) {
-            // ignore new messages for first sync
-            return;
-        }
+		
+        this.logger.debug({ msg: 'New message', uid: messageData.uid, flags: Array.from(messageData.flags), test: 'Test', notifyfrom: this.connection.notifyfrom});
 
         options.skipLock = true;
         options.headers = false;
@@ -427,7 +425,18 @@ class Mailbox {
             this.logger.debug({ msg: 'Not found', uid: messageData.uid });
             return;
         }
+		let date = messageInfo.date;
+		this.logger.debug({ messageDate: date });
 
+		let messageDate = moment(messageInfo.date);
+		let notifyFrom = moment(this.connection.notifyfrom);
+
+		this.logger.debug({ messageDateValue: messageDate.valueOf(), notifyFromValue: notifyFrom.valueOf() });
+		
+		if (messageDate < notifyFrom) {
+			return
+		}
+		
         await this.connection.notify(this, 'messageNew', messageInfo);
     }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "nodemailer": "6.4.11",
         "pino": "6.5.1",
         "prom-client": "12.0.0",
-        "wild-config": "1.5.1"
+        "wild-config": "1.5.1",
+		"moment": "^2.27.0"
     },
     "devDependencies": {
         "eslint": "7.8.1",

--- a/workers/api.js
+++ b/workers/api.js
@@ -347,7 +347,9 @@ const init = async () => {
 					
 					copy: Joi.boolean().example(true).description('Copy submitted messages to Sent folder').default(true),
 					
-					notifyfrom: Joi.date().example('01-01-2020').description('Notify messages from date').default('now').iso().raw(),
+					notifyFrom: Joi.date().example('01-01-2020').description('Notify messages from date').default('now').iso().raw(),
+
+					resyncDelay: Joi.number().example(900).description('Full resync delay in seconds').default(900),
 
                     imap: Joi.object(imapSchema).xor('useAuthServer', 'auth').description('IMAP configuration').label('IMAP'),
 

--- a/workers/api.js
+++ b/workers/api.js
@@ -344,6 +344,10 @@ const init = async () => {
                     account: Joi.string().max(256).required().example('example').description('Account ID'),
 
                     name: Joi.string().max(256).required().example('My Email Account').description('Display name for the account'),
+					
+					copy: Joi.boolean().example(true).description('Copy submitted messages to Sent folder').default(true),
+					
+					notifyfrom: Joi.date().example('01-01-2020').description('Notify messages from date').default('now').iso().raw(),
 
                     imap: Joi.object(imapSchema).xor('useAuthServer', 'auth').description('IMAP configuration').label('IMAP'),
 


### PR DESCRIPTION
I need to add three parameters to account in my project.
I think it will be very usefull for others too.

**copy (boolean)**- this parameter tells if submitted messages via API should be copied to Sent folder. Office365 works the same way as Gmail and automatically creates message in IMAP folder. Without this parameter we have duplicates in IMAP folders.
**notifyFrom (iso date)** - this parameter tells what messages should be notified via webhook during initial account synchronization.
**resyncDelay (number)**- this parameter tells how often in seconds full synchronization should run. Now this parameter is hardcoded to 15 min.

example json:
{
"account": "imapapi@xyz.com",
"name": "Test M365",
"copy": false,
"notifyFrom": "2020-09-01T00:00:00Z",
"resyncDelay": 60,
"imap": {
"host": "outlook.office365.com",
"port": 993,
"secure": true,
"auth": {
"user": "imapapi@xyz.com",
"pass": "secret"
}
},
"smtp": {
"host": "smtp.office365.com",
"port": 587,
"secure": false,
"auth": {
"user": "imapapi@xyz.com",
"pass": "secret"
}
}
}


Regards Adam
